### PR TITLE
Add a mechanism to specify build file snippets to substitute for the naive maven import rule.

### DIFF
--- a/test/test_workspace/BUILD.bazel
+++ b/test/test_workspace/BUILD.bazel
@@ -1,0 +1,3 @@
+exports_files([
+    "build_substitution_templates.bzl",
+])

--- a/test/test_workspace/WORKSPACE
+++ b/test/test_workspace/WORKSPACE
@@ -3,12 +3,28 @@ workspace(name = "test_workspace")
 # Set up maven
 local_repository(name = "maven_repository_rules", path = "../..")
 load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
+load(":build_substitution_templates.bzl", "DAGGER_PLUGIN_BUILD_SUBSTITUTE")
+
 maven_repository_specification(
     name = "maven",
     insecure_artifacts = [
-        "com.google.dagger:dagger:1.4",
+        "com.google.dagger:dagger:2.20",
+        "com.google.dagger:dagger-compiler:2.20",
+        "com.google.dagger:dagger-producers:2.20",
+        "com.google.dagger:dagger-spi:2.20",
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:javac-shaded:9+181-r4173-1",
+        "com.google.googlejavaformat:google-java-format:1.6",
+        "com.squareup:javapoet:1.11.1",
+        "org.checkerframework:checker-compat-qual:2.5.5",
+        "javax.annotation:jsr250-api:1.0",
+        "javax.inject:javax.inject:1",
+        "junit:junit:4.13-beta-1",
     ],
     artifacts = {
         "com.google.guava:guava:25.0-jre": "3fd4341776428c7e0e5c18a7c10de129475b69ab9d30aeafbb5c277bb6074fa9",
+    },
+    build_substitutes = {
+        "com.google.dagger:dagger": DAGGER_PLUGIN_BUILD_SUBSTITUTE.format(dagger_version = "2.20", repo = "maven"),
     }
 )

--- a/test/test_workspace/build_substitution_templates.bzl
+++ b/test/test_workspace/build_substitution_templates.bzl
@@ -1,0 +1,63 @@
+# Description:
+#   String variables containing build-file segment substitutes, to be used with the
+#   `maven_repository_specification(build_substitutes = {...})` dictionary property.  These have specific documentation
+#   on any template variables
+#
+#   Given the volatility (and lack of automation) of the deps lists in these substitutions, these templates aren't
+#   intended for generic usage.  They can be freely cut-and-pasted as given in this example file, but the deps list
+#   needs curation.  Indeed, it mostly only has variable substitution because the unversioned coordinates don't change
+#   so frequently.
+
+
+# Description:
+#   Substitutes the naive maven_jvm_artifact for com.google.dagger:dagger with a flagor that exports the compiler
+#   plugin.  Contains the `dagger_version` substitution variable.
+#
+# Usage:
+#
+#   maven_repository_specification(
+#       ...
+#       build_substitutes = {
+#           "com.google.dagger:dagger": DAGGER_PLUGIN_BUILD_SUBSTITUTE.format(dagger_version = "2.20", repo = "maven"),
+#       }
+#   )
+#
+# Note:
+#   This set of internal dependencies is valid as of dagger 2.20. Other versions may require different deps.
+#
+DAGGER_PLUGIN_BUILD_SUBSTITUTE = """
+java_library(
+    name = "dagger",
+    exports = [
+        ":dagger_api",
+        "@maven//javax/inject:javax_inject",
+    ],
+    exported_plugins = [":dagger_plugin"],
+    visibility = ["//visibility:public"],
+)
+
+maven_jvm_artifact(
+    name = "dagger_api",
+    artifact = "com.google.dagger:dagger:{dagger_version}",
+)
+
+java_plugin(
+    name = "dagger_plugin",
+    processor_class = "dagger.internal.codegen.ComponentProcessor",
+    generates_api = True,
+    deps = [
+        ":dagger_api",
+        ":dagger_compiler",
+        ":dagger_producers",
+        ":dagger_spi",
+        "@{repo}//com/google/code/findbugs:jsr305",
+        "@{repo}//com/google/errorprone:javac_shaded",
+        "@{repo}//com/google/googlejavaformat:google_java_format",
+        "@{repo}//com/google/guava",
+        "@{repo}//com/squareup:javapoet",
+        "@{repo}//org/checkerframework:checker_compat_qual",
+        "@{repo}//javax/annotation:jsr250_api",
+        "@{repo}//javax/inject:javax_inject",
+    ],
+)
+"""

--- a/test/test_workspace/java/foo/BUILD.bazel
+++ b/test/test_workspace/java/foo/BUILD.bazel
@@ -1,6 +1,10 @@
+package(default_visibility = ["//:__subpackages__"])
 
 java_library(
     name = "foo",
     srcs = ["Foo.java"],
-    deps = ["@maven//com/google/guava"],
+    deps = [
+        "@maven//com/google/dagger",
+        "@maven//com/google/guava",
+    ],
 )

--- a/test/test_workspace/java/foo/Foo.java
+++ b/test/test_workspace/java/foo/Foo.java
@@ -1,10 +1,30 @@
-package test.test_workspace.java.foo;
+package foo;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.inject.Inject;
 
-class Foo {
+public class Foo {
+  final ImmutableList<String> strings = ImmutableList.of();
 
-    List<String> strings = ImmutableList.of();
+  @Inject public Foo() {}
 
+  // Visible for testing
+  Foo(Iterable<String> strings) {
+    strings = ImmutableList.copyOf(strings);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof Foo && this.strings.equals(((Foo) o).strings);
+  }
+
+  @dagger.Component
+  interface FooComponent {
+    Foo foo();
+
+    static FooComponent create() {
+      return DaggerFoo_FooComponent.builder().build();
+    }
+  }
 }

--- a/test/test_workspace/javatests/foo/BUILD.bazel
+++ b/test/test_workspace/javatests/foo/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//:__subpackages__"])
+java_test(
+    name = "FooTest",
+    srcs = ["FooTest.java"],
+    deps = [
+        "//java/foo",
+        "@maven//junit",
+    ],
+)

--- a/test/test_workspace/javatests/foo/FooTest.java
+++ b/test/test_workspace/javatests/foo/FooTest.java
@@ -1,0 +1,10 @@
+package foo;
+
+import org.junit.Test;
+
+public class FooTest {
+  @Test public void testFoo() {
+    new Foo();
+
+  }
+}


### PR DESCRIPTION
Adds a mechanism to specify build file snippets to substitute for the auto-generated rule for a given artifact in the maven repo.

This ends up allowing things like replacing a naive java library/import with a java_plugin target, and a java_library which exports it.  It's a naive string substitution (which can be made richer with Starlark's pythonic string template formatting feature).

Also add more articulated tests, including using dagger (and a substituted build file snippet to export the annotation processor).