### PR TITLE
Refactor the rules to prepare for more complex features.

### DIFF
--- a/maven/artifacts.bzl
+++ b/maven/artifacts.bzl
@@ -1,0 +1,87 @@
+#
+# Utilities for processing maven artifact coordinates and generating useful structs.
+#
+
+# Artifact types supported by maven_jvm_artifact()
+_supported_jvm_artifact_packaging = [
+    "jar",
+    "aar",
+]
+# All supported artifact types (Can be extended for non-jvm packaging types.)
+_supported_artifact_packaging = _supported_jvm_artifact_packaging
+
+_artifact_template = "{group_path}/{artifact_id}/{version}/{artifact_id}-{version}.{suffix}"
+_artifact_template_with_classifier = "{group_path}/{artifact_id}/{version}/{artifact_id}-{version}-{classifier}.{suffix}"
+
+
+# Builds a struct containing the basic coordinate elements of a maven artifact spec.
+def _parse_spec(artifact_spec):
+    parts = artifact_spec.split(":")
+    packaging = "jar"
+    classifier = None
+    version = "UNKNOWN"
+
+    # parse spec
+    if len(parts) == 2:
+        group_id, artifact_id = parts
+    elif len(parts) == 3:
+        group_id, artifact_id, version = parts
+    elif len(parts) == 4:
+        group_id, artifact_id, version, packaging = parts
+    elif len(parts) == 5:
+        group_id, artifact_id, version, packaging, classifier = parts
+    else:
+        fail("Invalid artifact: %s" % artifact_spec)
+
+    return struct(
+        original_spec = artifact_spec,
+        group_id = group_id,
+        artifact_id = artifact_id,
+        packaging = packaging,
+        classifier = classifier,
+        version = version,
+    )
+
+# Builds an annotated struct from a more basic artifact struct, with standard paths, names, and other values
+# derived from the basic artifact spec elements.
+def _annotate_artifact(artifact):
+    # assemble paths and target names and such.
+    group_elements = artifact.group_id.split(".")
+    artifact_id_munged = artifact.artifact_id.replace("-", "_").replace(".", "_")
+    munged_classifier_if_present = (artifact.classifier.split("-") if artifact.classifier else [])
+    maven_target_elements = group_elements + [artifact_id_munged] + munged_classifier_if_present
+    maven_target_name = "_".join(maven_target_elements)
+    suffix = artifact.packaging # TODO(cgruber) support better packaging mapping, to handle .bundles etc.
+    group_path = "/".join(group_elements)
+    if bool(artifact.classifier):
+        path = None if not bool(artifact.version) else _artifact_template_with_classifier.format(
+            group_path = group_path,
+            artifact_id = artifact.artifact_id,
+            version = artifact.version,
+            classifier = artifact.classifier,
+        )
+    else:
+        path = None if not bool(artifact.version) else _artifact_template.format(
+            group_path = group_path,
+            artifact_id = artifact.artifact_id,
+            version = artifact.version,
+            suffix = suffix,
+        )
+
+    annotated_artifact = struct(
+        maven_target_name = maven_target_name,
+        third_party_target_name = artifact_id_munged,
+        path = path,
+        original_spec = artifact.original_spec,
+        group_id = artifact.group_id,
+        artifact_id = artifact.artifact_id,
+        packaging = artifact.packaging,
+        classifier = artifact.classifier,
+        version = artifact.version,
+    )
+    return annotated_artifact
+
+artifacts = struct(
+    parse_spec = _parse_spec,
+    annotate = _annotate_artifact,
+)


### PR DESCRIPTION
Also remove some extra "just in case" bits of the "annotated" artifact that aren't yet needed (YAGNI)

A key factoring out is the separation of parsing the artifact spec from annotating it with computed properties from those elements (such as paths).  The reason for this is to allow for much cheaper artifact parsing (basic split/destructuring) in some cases where we don't need the extra computed paths.  That's not needed yet but will be used in a planned (and being coded) feature, and it's a good logical separation anyway. 

